### PR TITLE
Changed "Previous" and "Next" to use &laquo; and &raquo; in article footer

### DIFF
--- a/layouts/article_footer.html
+++ b/layouts/article_footer.html
@@ -15,11 +15,19 @@
 
 <div class="clearfix pagination">
 
-  <% if @item[:previous_item] %>
-  <a href="<%= @item[:previous_item].path %>" class="previous"><span class="article"><%= @item[:previous_item][:title] %></span> <span class="direction">Previous</span></a>
-  <% end %>
-  <% if @item[:next_item] %>
-  <a href="<%= @item[:next_item].path %>" class="next"><span class="article"><%= @item[:next_item][:title] %></span> <span class="direction">Next</span></a>
-  <% end %>
+	<% if @item[:previous_item] %>
+	<a href="<%= @item[:previous_item].path %>" class="previous">
+		<span class="article">
+			&laquo;<%= @item[:previous_item][:title] %>
+		</span>
+	</a>
+	<% end %>
+	<% if @item[:next_item] %>
+	<a href="<%= @item[:next_item].path %>" class="next">
+		<span class="article">
+			<%= @item[:next_item][:title] %>&raquo;
+		</span>
+	</a>
+	<% end %>
 
 </div>


### PR DESCRIPTION
In the article footer layout, I removed the words `Previous` and `Next` and replaced them with the HTML elements `&laquo;` and `&raquo;` with the hope of making the links easier to read.  Take this page for example:

http://stage.learn.jquery.com/javascript-101/loops/

At the bottom of the article footer it says:

Conditional Code Previous
and
Reserved Words Next

My changes remove the words "Previous" and "Next" and instead using the html double-arrows mentioned above.

Also I slightly reformatted the HTML, moving items to individual lines to make it more readable.
