### PR TITLE
nanoc needs to compile or watch before the site is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ If you aren't already familiar with Git, you'll still need a fork and a GitHub a
 `> gem install bundler && bundle install`
 * Run the nanoc server<br/>
 `> nanoc view &`
-* The site should be running on http://localhost:3000. Use the `--port` option to specify a different port.
 * Set the site to watch for changes and re-compile<br/>
 `> nanoc watch`
+* The site should be running on http://localhost:3000. Use the `--port` option to specify a different port.
 
 ## I Don't (Know If I?) Already Have a Ruby Development Environment
 


### PR DESCRIPTION
This is a one line README change to reflect that nanoc compile or nanoc watch needs to be run before the site is available at localhost:3000.  I spent a few minutes trying to figure out what I was doing wrong, because I was expecting the site to be running after `> nanoc view &`
