### PR TITLE
fixed "use strict"

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -1,7 +1,8 @@
-use strict;
 var config = require("./config.json");
 
 module.exports = function( grunt ) {
+
+"use strict";
 
 grunt.loadNpmTasks( "grunt-clean" );
 grunt.loadNpmTasks( "grunt-html" );


### PR DESCRIPTION
fixed "use strict" for grunt 0.3.17 lint check

https://github.com/jquery/2012-dev-summit/issues/94

the grunt.js originally had use strict set incorrectly?
