### PR TITLE
Fixing syntax highlighting

### DIFF
--- a/page/plugins/basic-plugin-creation.md
+++ b/page/plugins/basic-plugin-creation.md
@@ -123,7 +123,7 @@ It would be much better to have one slot, and use parameters to control what act
 
   };
 }( jQuery )); 
-
+```
 
 ## Using the `each()` Method 
 Your typical jQuery object will contain references to any number of DOM elements, and that's why jQuery objects are often referred to as collections.  


### PR DESCRIPTION
Missing ending back ticks were throwing off the entire rest of the file's content and code highlighting
