### PR TITLE
Update page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-th...

### DIFF
--- a/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
+++ b/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
@@ -26,7 +26,7 @@ The following function takes care of escaping these characters and places a "#" 
 ```
 function jq( myid ) {
 
-  return "#" + myid.replace( /(:|\.)/g, "\\$1" );
+  return "#" + myid.replace( /(:|\.|\[|\])/g, "\\$1" );
 
 }
 ```


### PR DESCRIPTION
...at-has-characters-used-in-css-notation.md

The second example on http://api.jquery.com/id-selector/ shows us that [ and ] should be escaped too.
