### PR TITLE
 triggering-event-handlers - broken link to Microsoft

### DIFF
--- a/page/events/triggering-event-handlers.md
+++ b/page/events/triggering-event-handlers.md
@@ -29,7 +29,7 @@ $("a").trigger("click");
 
 ## How can I mimic a native browser event, if not `.trigger()`?
 
-In order to trigger a native browser event, you have to use [document.createEventObject](http://msdn.microsoft.com/en-us/library/ie/ms536390(v=vs.85).aspx) for < IE9 and  [document.createEvent](https://developer.mozilla.org/en/DOM/document.createEvent) for all other browsers.
+In order to trigger a native browser event, you have to use [document.createEventObject](http://msdn.microsoft.com/en-us/library/ie/ms536390.aspx) for < IE9 and  [document.createEvent](https://developer.mozilla.org/en/DOM/document.createEvent) for all other browsers.
 Using these two APIs, you can programatically create an event that behaves exactly as if someone has actually clicked on a file input box. The default action will happen, and the browse file dialog will display.
 
 The jQuery UI Team created [jquery.simulate.js](https://github.com/eduardolundgren/jquery-simulate/blob/master/jquery.simulate.js) in order to simplify triggering a native browser event for use in their automated testing. Its usage is modeled after jQuery's trigger.


### PR DESCRIPTION
In page learn.jquery.com / page / events / triggering-event-handlers.md
## the link "[document.createEventObject](http://msdn.microsoft.com/en-us/library/ie/ms536390%28v=vs.85%29.aspx)" renders to:
## In order to trigger a native browser event, you have to use document.createEventObject.aspx)

".aspx)" not included in the link.
