### PR TITLE
Update page/events/triggering-event-handlers.md

### DIFF
--- a/page/events/triggering-event-handlers.md
+++ b/page/events/triggering-event-handlers.md
@@ -16,7 +16,7 @@ jQuery's event handling system is a layer on top of native browser events. When 
 reference to that handler when it is originally added. Additionally, it will trigger the javascript inside the 
 "onclick" attribute. The `.trigger()` function cannot be used to mimic native browser events, such as 
 clicking on a file input box or an anchor tag. This is because, there is no event handler attached using jQuery's 
-event system that coorespond to these events.
+event system that corresponds to these events.
 
 ```
 <a href="http://learn.jquery.com">Learn jQuery</a>
@@ -29,7 +29,7 @@ $("a").trigger("click");
 
 ## How can I mimic a native browser event, if not `.trigger()`?
 
-In order to trigger a native browser event, you have to use [document.createEventObject](http://msdn.microsoft.com/en-us/library/ie/ms536390(v=vs.85).aspx) for < IE9 and  [document.createEvent](https://developer.mozilla.org/en/DOM/document.createEvent) for all other browsers.
+In order to trigger a native browser event, you have to use [document.createEventObject](http://msdn.microsoft.com/en-us/library/ie/ms536390%28v=vs.85%29.aspx) for < IE9 and  [document.createEvent](https://developer.mozilla.org/en/DOM/document.createEvent) for all other browsers.
 Using these two APIs, you can programatically create an event that behaves exactly as if someone has actually clicked on a file input box. The default action will happen, and the browse file dialog will display.
 
 The jQuery UI Team created [jquery.simulate.js](https://github.com/eduardolundgren/jquery-simulate/blob/master/jquery.simulate.js) in order to simplify triggering a native browser event for use in their automated testing. Its usage is modeled after jQuery's trigger.


### PR DESCRIPTION
- "coorespond" => "corresponds"
- fixed a link (hopefully) that contained brackets (which caused problems because the whole url is encapsulated in brackets as well) by using the url-encodings for the brackets.
