### PR TITLE
Update page/using-jquery-core/selecting-elements.md

### DIFF
--- a/page/using-jquery-core/selecting-elements.md
+++ b/page/using-jquery-core/selecting-elements.md
@@ -16,7 +16,7 @@ $("#myId"); // note IDs must be unique per page
 
 ```
 // Selecting elements by class name
-$("div.myClass"); // performance improves if you specify element type
+$(".myClass");
 ```
 
 ## Selecting Elements by Attribute


### PR DESCRIPTION
Qualification (prefixation) is no longer useful; as the modern browsers have the http://caniuse.com/#search=getElementsByClassName available, qualification even slows down the process.
Proof in: 
http://jsperf.com/jquery-class-vs-tag-qualfied-class-selector/10
