### PR TITLE
Fixed inconsistency in showLinkLocation example

### DIFF
--- a/page/plugins/basic-plugin-creation.md
+++ b/page/plugins/basic-plugin-creation.md
@@ -215,7 +215,7 @@ href attribute in brackets.
 <a href="page.html">Foo</a>
 
 <!-- After plugin is called: -->
-<a href="page.html">Foo [page.html]</a>
+<a href="page.html">Foo (page.html)</a>
 ```
 
 Our plugin can be optimized though:


### PR DESCRIPTION
showLinkLocation example function suggested link would be shown in parentheses, example output used square brackets.
