### PR TITLE
Fixed typo in a link

### DIFF
--- a/page/javascript-101/syntax-basics.md
+++ b/page/javascript-101/syntax-basics.md
@@ -8,7 +8,7 @@ attribution:
 
 ### Comments
 
-JavaScript has support for single- and multi-line comments. Comments are ignored by the JavaScript engine and therefore have no side-effects on the outcome of the program. Use comments to document the code for other developers. Libraries like [JSDoc](http://code.google.com/p/jsdoc-toolkit/) are available to help generate project documentation pages based on commenting conventions.
+JavaScript has support for single- and multi-line comments. Comments are ignored by the JavaScript engine and therefore have no side-effects on the outcome of the program. Use comments to document the code for other developers. Libraries like [JSDoc](http://code.google.com/p/jsdoc-toolkit/ "JSDoc Toolkit") are available to help generate project documentation pages based on commenting conventions.
 
 ```
 // Single and multi line comments.


### PR DESCRIPTION
Corrected the presence of an extra comma that broke the link to the JSDoc webpage.
