### PR TITLE
Revert incorrect statement regarding $.each object acess

### DIFF
--- a/page/using-jquery-core/iterating.md
+++ b/page/using-jquery-core/iterating.md
@@ -34,8 +34,9 @@ $.each( arr, function( index, value ){
 console.log( sum ); // 15
 ```
 
-Notice that `arr[ index ]` can't be accessed as the value is conveniently passed to the callback in `$.each()`. In addition, given:
+Notice that we don't have to access `arr[ index ]` as the value is conveniently passed to the callback in `$.each`.
 
+In addition, given: 
 ```
 var sum = 0;
 var obj = {
@@ -65,7 +66,9 @@ $.each( obj, function( key, value ) {
 console.log( sum ); // 3
 ```
 
-Again, `obj[ key ]` is passed directly to the callback and thus can't be accessed. Note that `$.each()` is for plain objects, arrays, array-like objects *that are not jQuery collections*.
+Again, we don't have to directly access `obj[ key ]` as the value is passed directly to the callback.
+
+Note that `$.each` is for plain objects, arrays, array-like objects *that are not jQuery collections*. 
 
 This would be considered incorrect:
 


### PR DESCRIPTION
Commit 9d45ae2 introduced a incorrect statement, stating that the object being iterated upon by $.each() can't be accessed inside the each function.  Reverted these two occurrences in the documentation to their state pre-9d45ae2.
