### PR TITLE
Updated example in performance/cache-loop-length

### DIFF
--- a/page/performance/cache-loop-length.md
+++ b/page/performance/cache-loop-length.md
@@ -9,6 +9,14 @@ attribution:
 In a for loop, don't access the length property of an array every time; cache
 it beforehand.
 
+Don't do this
+```
+for ( var i = 0; i < myArray.length; i++ ) {
+
+ // do stuff
+}
+```
+Do this 
 ```
 var myLength = myArray.length;
 


### PR DESCRIPTION
Added example for what not to do for comparison purposes.
