### PR TITLE
Use Google's CDN for how-jquery-works examples

### DIFF
--- a/page/about-jquery/how-jquery-works.md
+++ b/page/about-jquery/how-jquery-works.md
@@ -16,7 +16,7 @@ don't have a test page setup yet, start by creating the following HTML page:
 </head>
 <body>
 	<a href="http://jquery.com/">jQuery</a>
-	<script src="jquery.js"></script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
 	<script>
 	// Your code goes here
 	</script>
@@ -24,8 +24,9 @@ don't have a test page setup yet, start by creating the following HTML page:
 </html>
 ```
 
-The `src` attribute in the `<script>` element must point to a copy of jQuery.
-Download a copy of jQuery from the [Downloading jQuery](http://jquery.com/download/) page
+The `src` attribute in the `<script>` element must point to a copy of jQuery. The example
+uses the latest version of jQuery 1.x from the free Google CDN. You may want to download your
+own copy of jQuery from the [Downloading jQuery](http://jquery.com/download/) page
 and store the `jquery.js` file in the same directory as your HTML file.
 
 ### Launching Code on Document Ready
@@ -91,7 +92,7 @@ and load it on the page with a `<script>` element's `src` attribute.
 </head>
 <body>
 	<a href="http://jquery.com/">jQuery</a>
-	<script src="jquery.js"></script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
 	<script>
 	$( document ).ready(function() {
 		$( "a" ).click(function( event ) {


### PR DESCRIPTION
It's both best practice and easier for a user to try out as they don't
need to navigate downloading jQuery and saving it to the right place.

I've included the http: rather than start with // because people are
likely to run the tests on file:// URLs, and that case should work.
People are unlikely to try this out on https:// URLs, so there should
be no problem forcing http.
