### PR TITLE
Improve error callback example for $.ajax

### DIFF
--- a/page/ajax/jquery-ajax-methods.md
+++ b/page/ajax/jquery-ajax-methods.md
@@ -52,8 +52,11 @@ $.ajax({
 
 	// code to run if the request fails; the raw request and
 	// status codes are passed to the function
-	error: function( xhr, status ) {
+	error: function( xhr, status, errorThrown ) {
 		alert( "Sorry, there was a problem!" );
+		console.log( "Error: " + errorThrown );
+		console.log( "Status: " + status );
+		console.dir( xhr );
 	},
 
 	// code to run regardless of success or failure


### PR DESCRIPTION
The error handler includes two of the three parameters, but doesn't actually do anything with them. This is a very common place where new developers will get the "Sorry, there was a problem!" and not know how to go further to figure out what the problem was. Adding the logging may help improve that.
