### PR TITLE
Improve article attribution heuristic

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -93,7 +93,13 @@ grunt.registerHelper( "contributor-attribution", function( post, fileName, fn ) 
 	// Read contributors from git file information
 	grunt.utils.spawn({
 		cmd: "git",
-		args: [ "log", "--format=%aN <%aE>", fileName ]
+		args: [
+			"log",
+			"--follow", // Trace history through file rename operations
+			"--diff-filter=AM", // Only consider "Add" and "Modify" operations
+			"--format=%aN <%aE>",
+			fileName
+		]
 	}, function( err, result ) {
 		if ( err ) {
 			grunt.verbose.error();


### PR DESCRIPTION
Make the attribution algorithm trace through the history
across file rename operations, but do not consider such operations as an
indication of contribution.

The compiled output is a single line of JSON, making it a bit tough to inspect.
Here's what I did to try it out:

```
$ git checkout -b tmp master
$ grunt
$ git add -f dist
$ git commit -m "Current build"
$ git pull git@github.com:jugglinmike/learn.jquery.com.git follow-moves
$ grunt
$ git diff --word-diff --word-diff-regex="[^,\{]"
```

Basically, it adds contributors who created/edited articles prior to 0fb17c3b126823445015d373c738f5930af529d3 (including yours truly) and removes contributors whose only interaction with an article was to move it (i.e. @rdworth in  07113756905d4edead15191650fcf076ae354666 and 7b49f826153fc27f510322eb56f23f3b4743be29).
