### PR TITLE
fix broken chaining in basic-plugin-creation.md

### DIFF
--- a/page/plugins/basic-plugin-creation.md
+++ b/page/plugins/basic-plugin-creation.md
@@ -187,9 +187,11 @@ Here's an example of a small plugin using some of the techniques we've discussed
 
 	$.fn.showLinkLocation = function() {
 
-		return this.filter( "a" ).each(function() {
+		this.filter( "a" ).each(function() {
 			$( this ).append( " (" + $( this ).attr( "href" ) + ")" );
 		});
+		
+		return this;
 
 	};
 
@@ -216,9 +218,11 @@ Our plugin can be optimized though:
 
 	$.fn.showLinkLocation = function() {
 
-		return this.filter( "a" ).append(function() {
+		this.filter( "a" ).append(function() {
 			return " (" + this.href + ")";
 		});
+		
+		return this;
 
 	};
 


### PR DESCRIPTION
Unless you actually want the side-effect of filtering, so only `a` tags are left, the examples are wrong.
