### PR TITLE
the .index() with No Arguments ?

### DIFF
--- a/page/using-jquery-core/understanding-index.md
+++ b/page/using-jquery-core/understanding-index.md
@@ -26,20 +26,20 @@ console.log( "Index: " + $foo.index() ); // 1
 
 var $listItem = $( "li" );
 
-// This implicitly calls .last()
-console.log( "Index: " + $listItem.index() ); // 3
-console.log( "Index: " + $listItem.last().index() ); // 3
+// This implicitly calls .first()
+console.log( "Index: " + $listItem.index() ); // 1
+console.log( "Index: " + $listItem.first().index() ); // 1
 
 var $div = $( "div" );
 
-// This implicitly calls .last()
-console.log( "Index: " + $div.index() ); // 4
-console.log( "Index: " + $div.last().index() ); // 4
+// This implicitly calls .first()
+console.log( "Index: " + $div.index() ); // 0
+console.log( "Index: " + $div.first().index() ); // 0
 ```
 
 In the first example, `.index()` gives the zero-based index of `#foo1` within its parent. Since `#foo1` is the second child of its parent, `index()` returns 1.
 
-Potential confusion comes from the other examples of `.index()` in the above code.  When `.index()` is called on a jQuery object that contains more than one element, it does not calculate the index of the first element as might be expected, but instead calculates the index of the last element. This is equivalent to always calling `$jqObject.last().index();`.
+When `.index()` is called on a jQuery object that contains more than one element, it calculates the index of the first element.
 
 ## `.index()` with a String Argument
 


### PR DESCRIPTION
I test the code with jquery 1.10.1 in firefox. and the result is opposite with the 
discription 'When .index() is called on a jQuery object that contains more than one element, it does not calculate the index of the first element as might be expected, but instead calculates the index of the last element. ' .  
![tt](https://f.cloud.github.com/assets/4495830/773815/d355ef44-e943-11e2-8753-c5e03ca61fd3.png)
