### PR TITLE
updating Understand-index.md

### DIFF
--- a/page/using-jquery-core/understanding-index.md
+++ b/page/using-jquery-core/understanding-index.md
@@ -41,7 +41,9 @@ In the first example, `.index()` gives the zero-based index of `#foo1` within it
 
 Potential confusion comes from the other examples of `.index()` in the above code.  When `.index()` is called on a jQuery object that contains more than one element, it does not calculate the index of the first element as might be expected, but instead calculates the index of the last element. This is equivalent to always calling `$jqObject.last().index();`.
 
-as of **jQuery version 1.10.2** the above code would produce the following result
+
+As of **jQuery version 1.9.0b1** the `.index()` functions uses `.first()` instead of `.last()`,
+so on versions greater than **1.9.0b1** the above code would produce the following result.
 
 ```
 var $foo = $( "#foo1" );


### PR DESCRIPTION
as of version 1.9.1 the index uses the .first method instead of .last
check the code in the .min.js attached `index:function(e){return e?"string"==typeof e?x.inArray(this[0],x(e)):x.inArray(e.jquery?e[0]:e,this):this[0]&&this[0].parentNode?this.first().prevAll().length:-1}`
