### PR TITLE
fixing issue#422 on wrong output in newer jQuery versions

### DIFF
--- a/page/using-jquery-core/understanding-index.md
+++ b/page/using-jquery-core/understanding-index.md
@@ -41,6 +41,26 @@ In the first example, `.index()` gives the zero-based index of `#foo1` within it
 
 Potential confusion comes from the other examples of `.index()` in the above code.  When `.index()` is called on a jQuery object that contains more than one element, it does not calculate the index of the first element as might be expected, but instead calculates the index of the last element. This is equivalent to always calling `$jqObject.last().index();`.
 
+As of versions greater than **1.8.3** the jQuery index implecitly call the `.first()`, so the result of the above code on versions greater than **1.8.3** will be
+
+```
+var $foo = $( "#foo1" );
+
+console.log( "Index: " + $foo.index() ); // 1
+
+var $listItem = $( "li" );
+
+// This implicitly calls .first()
+console.log( "Index: " + $listItem.index() ); // 1
+console.log( "Index: " + $listItem.index().index() ); // 1
+
+var $div = $( "div" );
+
+// This implicitly calls .first()
+console.log( "Index: " + $div.index() ); // 0
+console.log( "Index: " + $div.first().index() ); // 0
+```
+
 ## `.index()` with a String Argument
 
 ```


### PR DESCRIPTION
the output of the `.index()` will vary in versions greater than **1.8.3**

as the code in version 1.8.3 changed from

```
        // Determine the position of an element within
    // the matched set of elements
    index: function( elem ) {

        // No argument, return index in parent
        if ( !elem ) {
            return ( this[0] && this[0].parentNode ) ? this.prevAll().length : -1;
        }

        // index in selector
        if ( typeof elem === "string" ) {
            return jQuery.inArray( this[0], jQuery( elem ) );
        }

        // Locate the position of the desired element
        return jQuery.inArray(
            // If it receives a jQuery object, the first element is used
            elem.jquery ? elem[0] : elem, this );
    },
```

to 

```
        // Determine the position of an element within
    // the matched set of elements
    index: function( elem ) {

        // No argument, return index in parent
        if ( !elem ) {
            return ( this[0] && this[0].parentNode ) ? this.first().prevAll().length : -1;
        }

        // index in selector
        if ( typeof elem === "string" ) {
            return jQuery.inArray( this[0], jQuery( elem ) );
        }

        // Locate the position of the desired element
        return jQuery.inArray(
            // If it receives a jQuery object, the first element is used
            elem.jquery ? elem[0] : elem, this );
    },
```

in version **1.9.0b1** and newer versions
