### PR TITLE
Update conditional-code.md

### DIFF
--- a/page/javascript-101/conditional-code.md
+++ b/page/javascript-101/conditional-code.md
@@ -115,6 +115,8 @@ var stuffToDo = {
 
 };
 
+var foo;
+
 // Check if the property exists in the object.
 if ( stuffToDo[ foo ] ) {
 	// This code won't run.


### PR DESCRIPTION
1. The non-existence of 'var foo;' issues an error (Uncaught ReferenceError: foo is not defined), in chrome, at 'if ( stuffToDo[ foo ] ) {'.
## 2. The code (without var foo;) works fine in Safari.

Javascript Novice
