### PR TITLE
Update widget page to describe correct getter function

### DIFF
--- a/page/plugins/stateful-plugins-with-widget-factory.md
+++ b/page/plugins/stateful-plugins-with-widget-factory.md
@@ -140,7 +140,7 @@ alert( bar.progressbar( "value" ) );
 
 ### Working with Widget Options
 
-One of the methods that is automatically available to our plugin is the option method. The option method allows you to get and set options after initialization. This method works exactly like jQuery's `.css()` and `.attr()` methods: you can pass just a name to use it as a setter, a name and value to use it as a single setter, or a hash of name/value pairs to set multiple values. When used as a getter, the plugin will return the current value of the option that corresponds to the name that was passed in. When used as a setter, the plugin's `_setOption` method will be called for each option that is being set. We can specify a `_setOption` method in our plugin to react to option changes.
+One of the methods that is automatically available to our plugin is the option method. The option method allows you to get and set options after initialization. This method works exactly like jQuery's `.css()` and `.attr()` methods: you can pass just a name to use it as a getter, a name and value to use it as a single setter, or a hash of name/value pairs to set multiple values. When used as a getter, the plugin will return the current value of the option that corresponds to the name that was passed in. When used as a setter, the plugin's `_setOption` method will be called for each option that is being set. We can specify a `_setOption` method in our plugin to react to option changes.
 
 Responding when an option is set:
 


### PR DESCRIPTION
Previously page described use of option method as:

```
var bar = $( "<div />")
    .appendTo( "body" )
    .progressbar()
    .data( "progressbar" );

bar.option( "value"); // Setter
```

This correction describes the usage of the option method as:

```
var bar = $( "<div />")
    .appendTo( "body" )
    .progressbar()
    .data( "progressbar" );

bar.option( "value"); // Getter
```
