### PR TITLE
Fix an incorrect sentence for a code example.

### DIFF
--- a/page/javascript-101/scope.md
+++ b/page/javascript-101/scope.md
@@ -121,7 +121,7 @@ sayHello(); // "hello"
 console.log( foo ); // "world"
 ```
 
-When you reference a global variable within a function, that function can see changes to the variable value after the function is defined.
+When you reference a variable that's outside of a function's scope, that function can see changes to that variable after the function is defined and then executed.
 
 ```
 var myFunction = function() {


### PR DESCRIPTION
The code states the function references a global variable, but it
doesn't, it just references a variable outside the scope of the
function.

Hat tip to @matbad who emailed me to point out my mistake.

This code example isn't necessarily the best or most clear...so the discussion here might be to just remove this example, or add a clearer one, but I did fix the original error.
