### PR TITLE
Replace to use correct name

### DIFF
--- a/page/javascript-101/getting-started.md
+++ b/page/javascript-101/getting-started.md
@@ -80,5 +80,5 @@ Commonly referred to as "developer tools," many browsers ship with built-in feat
 - [Apple Safari](https://developer.apple.com/technologies/safari/developer-tools.html)
 - [Google Chrome Developer Tools](https://developers.google.com/chrome-developer-tools/)
 - [Microsoft Internet Explorer](http://msdn.microsoft.com/en-us/library/ie/gg589507.aspx)
-- [Mozilla Firefox Web Development Tools](https://developer.mozilla.org/en-US/docs/Tools)
+- [Mozilla Firefox Developer Tools](https://developer.mozilla.org/en-US/docs/Tools)
 - [Opera Dragonfly](http://www.opera.com/dragonfly/)


### PR DESCRIPTION
I believe Mozilla has been pretty consistent to calling it Firefox Developer Tools ([1](https://wiki.mozilla.org/DevTools), [2](https://hacks.mozilla.org/2013/11/reintroducing-the-firefox-developer-tools-part-2-the-scratchpad-and-the-style-editor/), [3](https://hacks.mozilla.org/2013/11/live-editing-webgl-shaders-with-firefox-developer-tools/), [4](https://hacks.mozilla.org/2012/09/html-editing-and-other-improvements-in-firefox-17-developer-tools/), and [5](https://developer.mozilla.org/en-US/docs/Tools))
