### PR TITLE
Sentence syntax correction

### DIFF
--- a/page/using-jquery-core/manipulating-elements.md
+++ b/page/using-jquery-core/manipulating-elements.md
@@ -34,7 +34,7 @@ While there are a variety of ways to move elements around the DOM, there are gen
 *	Place the selected element(s) relative to another element.
 *	Place an element relative to the selected element(s).
 
-For example, jQuery provides `.insertAfter()` and `.after()`. The `.insertAfter()` method places the selected element(s) after the element that provided as an argument. The `.after()` method places the element provided as an argument after the selected element. Several other methods follow this pattern: `.insertBefore()` and `.before()`, `.appendTo()` and `.append()`, and `.prependTo()` and `.prepend()`.
+For example, jQuery provides `.insertAfter()` and `.after()`. The `.insertAfter()` method places the selected element(s) after the element provided as an argument. The `.after()` method places the element provided as an argument after the selected element. Several other methods follow this pattern: `.insertBefore()` and `.before()`, `.appendTo()` and `.append()`, and `.prependTo()` and `.prepend()`.
 
 The method that makes the most sense will depend on what elements are selected, and whether you need to store a reference to the elements you're adding to the page. If you need to store a reference, you will always want to take the first approach – placing the selected elements relative to another element – as it returns the element(s) you're placing. In this case, `.insertAfter()`, `.insertBefore()`, `.appendTo()`, and `.prependTo()` should be the tools of choice.
 


### PR DESCRIPTION
The original sentence does not make sense - "The ... method places the selected element(s) after the element that provided as an argument".  "that was provided" would make more sense, but so does "the element provided", which is the syntax used in the following, similar sentence.
