### PR TITLE
Delegation, descendants but not only children elements will be checked to match

### DIFF
--- a/page/events/event-delegation.md
+++ b/page/events/event-delegation.md
@@ -71,7 +71,7 @@ $( "#list" ).on( "click", "a", function( event ) {
 });
 ```
 
-Notice how we have moved the `a` part from the selector to the second parameter position of the `.on()` method. This second, selector parameter tells the handler to listen for the specified event, and when it hears it, check to see if the triggering element for that event matches the second parameter. In this case, the triggering event is our anchor tag, which matches that parameter. Since it matches, our anonymous function will execute. We have now attached a single *click* event listener to our `<ul>` that will listen for clicks on its descendants anchors, instead of attaching an unknown number of directly bound events to the existing anchor tags only.
+Notice how we have moved the `a` part from the selector to the second parameter position of the `.on()` method. This second, selector parameter tells the handler to listen for the specified event, and when it hears it, check to see if the triggering element for that event matches the second parameter. In this case, the triggering event is our anchor tag, which matches that parameter. Since it matches, our anonymous function will execute. We have now attached a single *click* event listener to our `<ul>` that will listen for clicks on its descendant anchors, instead of attaching an unknown number of directly bound events to the existing anchor tags only.
 
 ### Using the Triggering Element
 


### PR DESCRIPTION
I just replaced children with descendants for this commit.
It is for this page https://learn.jquery.com/events/event-delegation/
