### PR TITLE
bower install jquery-ui not correct

### DIFF
--- a/page/jquery-ui/environments/bower.md
+++ b/page/jquery-ui/environments/bower.md
@@ -39,7 +39,7 @@ This examples fails with a JavaScript error because neither jQuery core nor jQue
 
 ### Downloading jQuery UI With Bower
 
-Libraries are downloaded with Bower using the `bower install` command. To install jQuery UI, run `bower install jquery-ui`. Doing so creates the following (simplified) directory structure.
+Libraries are downloaded with Bower using the `bower install` command. To install jQuery UI, run `bower install https://github.com/jquery/jquery-ui.git#1.11.0-beta.2`. Doing so creates the following (simplified) directory structure.
 
 *Note: If you get an error that the `bower` command is not found, checkout [Bower's installation instructions](http://bower.io/#installing-bower).*
 


### PR DESCRIPTION
to get the jQuery UI AMD version I had to do 

> bower install https://github.com/jquery/jquery-ui.git#1.11.0-beta.2

the way you wrote it, 

> bower install jquery-ui

Does not go to the correct repo. Or, am I missing something here?

bower info jquery-ui
bower not-cached    git://github.com/components/jqueryui.git#*
bower resolve       git://github.com/components/jqueryui.git#*
bower download      https://github.com/components/jqueryui/archive/1.10.4.tar.gz
bower extract       jquery-ui#\* archive.tar.gz
bower resolved      git://github.com/components/jqueryui.git#1.10.4

{
  name: 'jquery-ui',
  version: '1.10.4',
  main: [
    'ui/jquery-ui.js'
  ],
  dependencies: {
    jquery: '>=1.6'
  },
  homepage: 'https://github.com/components/jqueryui'
}

Available versions:
- 1.10.4
- 1.10.3
- 1.10.2
- 1.10.1
- 1.10.0
- 1.9.2
- 1.9.1
- 1.9.0
- 1.8.23
