### PR TITLE
Move the section on DOM earlier in the tutorial

### DIFF
--- a/page/using-jquery-core/jquery-object.md
+++ b/page/using-jquery-core/jquery-object.md
@@ -11,6 +11,7 @@ The Document Object Model (DOM for short) is a representation of an HTML documen
 
 Elements have properties like any JavaScript object. Among these properties are attributes like `.tagName` and methods like `.appendChild()`. These properties are the only way to interact with the web page via JavaScript.
 
+
 ## The jQuery Object
 
 It turns out that working directly with DOM elements can be awkward. The jQuery object defines [many](http://api.jquery.com/) methods to smooth out the experience for developers. Some benefits of the jQuery Object include:


### PR DESCRIPTION
DOM is already used earlier in the tutorial (e.g. http://learn.jquery.com/using-jquery-core/selecting-elements/) without being defined. The description here is great, but it should go before the first time in the tutorial when it is used. I think it probably deserves its own page.
