### PR TITLE
Fix first two code samples.

### DIFF
--- a/page/javascript-101/scope.md
+++ b/page/javascript-101/scope.md
@@ -29,6 +29,8 @@ function myFunc() {
 	var x = 5;
 }
 
+myFunc();
+
 console.log( x ); // ReferenceError: x is not defined
 ```
 
@@ -42,6 +44,8 @@ If you declare a variable and forget to use the `var` keyword, that variable is 
 function myFunc() {
 	x = 5;
 }
+
+myFunc();
 
 console.log( x ); // 5
 ```


### PR DESCRIPTION
The original sample below will really give out a Reference Error since the function wasn't called in the first place.

```js
function myFunc() { x = 5; }
console.log( x ); // 5
```
It should be:
```js
function myFunc() { x = 5; }
myFunc()
console.log( x ); // 5
```
