### PR TITLE
there is a mistake

### DIFF
--- a/page/javascript-101/operators.md
+++ b/page/javascript-101/operators.md
@@ -83,7 +83,7 @@ bar || foo;
 foo && bar;
 
 // returns 2, which is true
-foo && baz;
+bar && baz;
 
 // returns 1, which is true
 baz && foo;


### PR DESCRIPTION
// returns 2, which is true
foo && baz;

//should be
bar && baz
