### PR TITLE
Clarify comment in `javascript-101/operations`

### DIFF
--- a/page/javascript-101/operators.md
+++ b/page/javascript-101/operators.md
@@ -43,7 +43,7 @@ In JavaScript, numbers and strings will occasionally behave in unexpected ways.
 var foo = 1;
 var bar = "2";
 
-console.log( foo + bar ); // 12
+console.log( foo + bar ); // "12"
 ```
 
 ```


### PR DESCRIPTION
Adding quote around an console.log string output clarifies that it's
actually a string. In this article this really makes sense.

This would fix https://github.com/jquery/learn.jquery.com/issues/542.
