### PR TITLE
Add note on bug with `.index()` before 1.9

### DIFF
--- a/page/using-jquery-core/understanding-index.md
+++ b/page/using-jquery-core/understanding-index.md
@@ -38,7 +38,8 @@ console.log( "Index: " + div.first().index() ); // 0
 
 In the first example, `.index()` gives the zero-based index of `#foo1` within its parent. Since `#foo1` is the second child of its parent, `index()` returns 1.
 
-When `.index()` is called on a jQuery object that contains more than one element, it calculates the index of the first element.
+
+__Note__: Before jQuery 1.9, `.index()` only worked reliably on a single element, which is why we've used `.first()` on each of our examples. In jQuery 1.9+ this can be ignored, as the API was updated to define that it operates on the first element only.
 
 ## `.index()` with a String Argument
 


### PR DESCRIPTION
Added a little note on the bug with `.index()` in jquery < 1.9.

The examples were fixed with https://github.com/jquery/learn.jquery.com/commit/54946db1e37164f5f4154f6bded0236abbe6655c, where `.first()` was added without including any explanation about it. This results in even more confusion.

In general this needs to be known by people, so makes sense to include it.

Would fix https://github.com/jquery/learn.jquery.com/issues/276.
