### PR TITLE
events/basics: fix example

### DIFF
--- a/page/events/event-basics.md
+++ b/page/events/event-basics.md
@@ -42,7 +42,7 @@ $( document ).ready(function(){
 	// Now create a new button element with the alert class. This button
 	// was created after the click listeners were applied above, so it
 	// will not have the same click behavior as its peers
-	$( "button" ).addClass( "alert" ).appendTo( document.body );
+	$( "<button class='alert'>Alert!</button>" ).appendTo( document.body );
 });
 ```
 


### PR DESCRIPTION
Fix for https://github.com/jquery/learn.jquery.com/issues/584. This fixes the broken example in `events/basics`.

Two things I changed:
- Changed `$( "button" )` to `$( "<button>" )`, which was our original intent. This creates a new button to be appended to the body, instead of selecting the existing one. That was the original idea of the example (see comments L42-44)
-  Also added some `.text()` to that newly created button, technically it works without but it doesn't feel right and it's confusing.
