### PR TITLE
about-jquery/additional-support: remove old IRC channels

### DIFF
--- a/page/about-jquery/additional-support.md
+++ b/page/about-jquery/additional-support.md
@@ -84,8 +84,6 @@ If your problem is more in-depth, we may ask you to post to the mailing list, or
 
 You can also connect at http://webchat.freenode.net/?channels=#jquery.
 
-Additionally we have `#jquery-es` and `#jquery-de` if you want to speak your native language.
-
 If you wish to post code snippets to the channel, you should use a paste site, like [jsfiddle.net](http://jsfiddle.net/) or [jsbin.com](http://jsbin.com/).
 
 ### StackOverflow


### PR DESCRIPTION
Removed the `jquery-es` and `jquery-de` IRC channels. Both are inactive these days. `jquery-es` totally doesn't exist anymore, and `jquery-de` just doesn't have anybody in there anymore.
