### PR TITLE
Javascript-101/testing-type: format type correctly

### DIFF
--- a/page/javascript-101/testing-type.md
+++ b/page/javascript-101/testing-type.md
@@ -5,7 +5,7 @@
 	"attribution": [ "jQuery Fundamentals" ]
 }</script>
 
-JavaScript offers a way to test the type of a variable. However, the result can be confusing – for example, the type of an array is "Object."
+JavaScript offers a way to test the type of a variable. However, the result can be confusing – for example, the type of an array is `object`.
 
 It's common practice to use the `typeof` operator when trying to determining the type of a specific value.
 


### PR DESCRIPTION
Three little corrections to the formatting of a a type in `javascript-101/testing-type`:
- The type itself must not have a capital `O`. It's not a constructor.

``` sh
> typeof []
'object'
```
- It's 'code', so it must be wrapped within backticks.
- The dot ending the sentence must be outside of the backticks.
