### PR TITLE
Attributions: replace contributor list by link in `/about`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,6 @@ For more advice on managing your fork and submitting pull requests to the jQuery
 
 Yes! Take a look at our [style guide](http://learn.jquery.com/style-guide) for more information on authoring and formatting conventions.
 
-## How Will My Contribution Be Acknowledged?
-
-We will build the attribution of an article based on the git commit logs and present this information on the site.
-
 <h2 id="getting-help">Getting Help</h2>
 
 If you're struggling to get any part of the site working properly, or have any questions, we're here to help.

--- a/page/about.md
+++ b/page/about.md
@@ -28,6 +28,10 @@ The first is Rebecca Murphey's [jQuery Fundamentals](http://jqfundamentals.com/l
 
 The second is [docs.jquery.com](http://docs.jquery.com), that erstwhile chestnut still living out its final days before it will be shut down in early 2013. Since we've moved the API documentation for jQuery Core off that domain, we needed a place that could serve a similar need – documentation (that anyone can contribute to) that gets into the "how-to" and FAQs – without clumsy barriers to entry like finding the right person to set you up with a special wiki account and forcing all authoring into a `<textarea>`.
 
+## Contributing
+
+This project wouldn't have been possible without all our [awesome contributors](https://github.com/jquery/learn.jquery.com/graphs/contributors?type=a). If you feel like something on the site is open for improvements, you can contribute [on GitHub](https://github.com/jquery/learn.jquery.com). Feel free to check out [the contributing guide](contributing/) for more in-depth information.
+
 <h2 id="beta">About the Beta</h2>
 
 Though this resource will never truly be "done," the current version of this site should still be considered something of a preview. We still have a number of improvements we want to make to the content, user experience, and site build before we're ready to call it a "final release." At the same time, however, it's important for us to open the doors now so we can begin providing better docs to people who need them right away and spread the word about this effort. If you're interested in helping us reach the finish line, we invite you to please read more about how [you can get involved with contributing](/contributing/)!

--- a/page/style-guide.md
+++ b/page/style-guide.md
@@ -29,7 +29,7 @@ Each article should have the following header (see below as some metatags are op
 }</script>
 ```
 
-The `source` and `attribution` properties are optional, and should be used primarily if you are importing an article from an outside source where it was published before being donated for inclusion in the learn site. You should **not** include these properties if you are adding a new article or editing an existing one, as your contribution will be acknowledged via the git commit logs.
+The `source` and `attribution` properties are optional, and should be used primarily if you are importing an article from an outside source where it was published before being donated for inclusion in the learn site. You should **not** include these properties if you are writing a new article or editing an existing one.
 
 ### Code Blocks
 


### PR DESCRIPTION
__To be sure things don't break, this must be merged together with https://github.com/jquery/jquery-wp-content/pull/334. Don't merge this yet!__

This together with the other PR would close https://github.com/jquery/learn.jquery.com/issues/602.

It replaces the contributors section under every page with an shoutout in the `about/` page.