### PR TITLE
code-organization/concepts: add link to requireJS site

### DIFF
--- a/page/code-organization/concepts.md
+++ b/page/code-organization/concepts.md
@@ -5,7 +5,7 @@
 	"attribution": [ "jQuery Fundamentals" ]
 }</script>
 
-When you move beyond adding simple enhancements to your website with jQuery and start developing full-blown client-side applications, you need to consider how to organize your code. In this chapter, we'll take a look at various code organization patterns you can use in your jQuery application and explore the RequireJS dependency management and build system.
+When you move beyond adding simple enhancements to your website with jQuery and start developing full-blown client-side applications, you need to consider how to organize your code. In this chapter, we'll take a look at various code organization patterns you can use in your jQuery application and explore the [RequireJS](http://requirejs.org/) dependency management and build system.
 
 ## Key Concepts
 


### PR DESCRIPTION
This would fix https://github.com/jquery/learn.jquery.com/issues/530. Added a link to the RequireJS site. We don't have a real tutorial in here, so this might be the best.