### PR TITLE
code-organization/feature-browser-detection: refresh post

### DIFF
--- a/page/code-organization/feature-browser-detection.md
+++ b/page/code-organization/feature-browser-detection.md
@@ -14,13 +14,13 @@ In general, we recommend specific feature detection. Let's look at why.
 
 ### Browser Detection
 
-Browser detection is a method where the browser's User Agent (UA) string is checked for a particular pattern unique to a browser family or version. For example, this is Chrome 18's UA string on Mac OS X Lion:
+Browser detection is a method where the browser's User Agent (UA) string is checked for a particular pattern unique to a browser family or version. For example, this is Chrome 39's UA string on Mac OS X Yosemite:
 
 ```
-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.142 Safari/535.19
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.99 Safari/537.36
 ```
 
-Browser UA detection may check this string for something like "Chrome" or "Chrome/18" or any other part the developer feels identifies the browser they intend to target.
+Browser UA detection may check this string for something like "Chrome" or "Chrome/39" or any other part the developer feels identifies the browser they intend to target.
 
 While this seems to be an easy solution, there are several problems:
 
@@ -51,7 +51,6 @@ Now how would you go about doing that?
 There are several ways to go about feature detection:
 
 * Straight JavaScript
-* `$.support`
 * A Helper Library
 
 #### Straight JavaScript
@@ -70,23 +69,11 @@ if ( elem.getContext && elem.getContext( "2d" ) ) {
 }
 ```
 
-This is a very simple way to provide conditional experiences, depending on the features present in the user's browser. We can extract this into a helper function for reuse, but still have to write a test for every feature we're concerned about. This can be time-consuming and error-prone.
-
-What if someone else wrote all of that for us?
-
-#### $.support
-
-jQuery performs many tests to determine feature support to allow cross-browser use of many of the features we've come to love. jQuery's internal feature detection can be accessed through [jQuery.support](http://api.jquery.com/jQuery.support/).
-
-However, we do not recommend this for general use. As the API page says:
-
-> Since jQuery requires these tests internally, they must be performed on every page load. Although some of these properties are documented below, they are not subject to a long deprecation/removal cycle and may be removed once internal jQuery code no longer needs them.
-
-This detection may be removed from jQuery without notice. That's reason enough not to use it. What other options do we have?
+This is a very simple way to provide conditional experiences, depending on the features present in the user's browser. We can extract this into a helper function for reuse, but still have to write a test for every feature we're concerned about. This can be time-consuming and error-prone. Instead you might be interested in using a helper library.
 
 #### A Helper Library
 
-Thankfully, there are some great helper libraries (like [Modernizr](http://modernizr.com)) that provide a simple, high-level API for determining if a browser has a specific feature available or not.
+Thankfully, there are some great helper libraries (like [Modernizr](http://modernizr.com/)) that provide a simple, high-level API for determining if a browser has a specific feature available or not.
 
 For example, utilizing Modernizr, we are able to do the same canvas detection test with this code:
 
@@ -98,25 +85,13 @@ if ( Modernizr.canvas ) {
 }
 ```
 
-That's it. Easy.
+For more in-depth information on Modernizr, feel free to check out their [documentation](http://modernizr.com/docs/).
 
 ### Performance Considerations
 
 So, while the Modernizr syntax is great, it can end up being quite cumbersome to have several conditionals. Secondly, we're sending the code for both conditions to every browser, regardless if we'll need it or not.
 
-The `Modernizr` object exposes a `load()` method that many prefer over the syntax mentioned previously. This is due to another library that Modernizr now uses internally: [yepnope](http://yepnopejs.com/). Testing for canvas can now become something like this:
-
-```
-Modernizr.load({
-	test: Modernizr.canvas,
-	yep: "canvas.js",
-	nope: "canvas-polyfill.js"
-});
-```
-
-Using the `load` method allows us to send only the required polyfills and code over the wire. You can also pass an array of objects as an argument to `.load()`, and it will serve the correct files to the correct audience.
-
-Additionally, Modernizr has a [production build configurator](http://modernizr.com/download/) that allows you to specify exactly what parts of Modernizr you want to include and exclude the parts you don't.
+If you're using Modernizr, we highly encourage you to use the [build configurator](http://modernizr.com/download/), a tool that allows you to create custom builds of the library. You can exclude checks you don't need, which will save bytes and reduce the time it takes the page to load. Running every check that Modernizr can do, even when you don't need them, can slow down the page load.
 
 ### Other Resources
 
@@ -124,13 +99,12 @@ Additionally, Modernizr has a [production build configurator](http://modernizr.c
 
 * [modernizr](http://modernizr.com/) — Conditionally check to see if a specific feature is available in a browser.
 * [html5please](http://html5please.com/) — Use the new and shiny responsibly.
-* [html5please api](http://api.html5please.com/) — An API you can query to see how good (or bad) support for a specific feature is.
+* [html5please API](http://api.html5please.com/) — An API you can query to see how good (or bad) support for a specific feature is.
 * [caniuse](http://caniuse.com/) — Browser compatibility tables for HTML5, CSS3, SVG, etc.
-* [yepnope](http://yepnopejs.com/) — Conditional polyfill loader.
 
 #### Helpful Articles
 
 * [Browser Feature Detection](https://developer.mozilla.org/en-US/docs/Browser_Feature_Detection)
 * [Using Modernizr to detect HTML5 and CSS3 browser support](http://www.adobe.com/devnet/dreamweaver/articles/using-modernizr.html)
-* [Polyfilling the html5 gap](http://addyosmani.com/polyfillthehtml5gaps/slides/#1) by Addy Osmani
+* [Polyfilling the HTML5 gaps](http://addyosmani.com/polyfillthehtml5gaps/slides/#1) by Addy Osmani
 * [Feature, Browser, and Form Factor Detection: It's Good for the Environment](http://www.html5rocks.com/en/tutorials/detection/index.html) by Michael Mahemoff


### PR DESCRIPTION
See https://github.com/jquery/learn.jquery.com/issues/610. This does some little tweaks to refresh the article to 2015 vintage. Also this removes deprecated content in this article: `Modernizr.load`, yepnope, `$.support`, ...

The article is in no way complete after this, but at least it removes/replaces the _really_ outdated stuff.