### PR TITLE
Changed the position of the full stop to enforce clarity

### DIFF
--- a/page/using-jquery-core/document-ready.md
+++ b/page/using-jquery-core/document-ready.md
@@ -3,7 +3,7 @@
 	"level": "beginner"
 }</script>
 
-A page can't be manipulated safely until the document is "ready." jQuery detects this state of readiness for you. Code included inside `$( document ).ready()` will only run once the page Document Object Model (DOM) is ready for JavaScript code to execute. Code included inside `$( window ).load(function() { ... })` will run once the entire page (images or iframes), not just the DOM, is ready.
+A page can't be manipulated safely until the document is "ready". jQuery detects this state of readiness for you. Code included inside `$( document ).ready()` will only run once the page Document Object Model (DOM) is ready for JavaScript code to execute. Code included inside `$( window ).load(function() { ... })` will run once the entire page (images or iframes), not just the DOM, is ready.
 
 ```
 // A $( document ).ready() block.


### PR DESCRIPTION
This is a quick fix to remove the full stop from the quotation marks so as to isolate the keyword  "ready"