### PR TITLE
Replacing references to deprecated methods

### DIFF
--- a/page/ajax/jquery-ajax-methods.md
+++ b/page/ajax/jquery-ajax-methods.md
@@ -17,42 +17,41 @@ jQuery’s core `$.ajax()` method is a powerful and straightforward way of creat
 // Using the core $.ajax() method
 $.ajax({
 
-	// The URL for the request
-	url: "post.php",
+    // The URL for the request
+    url: "post.php",
 
-	// The data to send (will be converted to a query string)
-	data: {
-		id: 123
-	},
+    // The data to send (will be converted to a query string)
+    data: {
+        id: 123
+    },
 
-	// Whether this is a POST or GET request
-	type: "GET",
+    // Whether this is a POST or GET request
+    type: "GET",
 
-	// The type of data we expect back
-	dataType : "json",
+    // The type of data we expect back
+    dataType : "json",
+  })
+    // Code to run if the request succeeds (is done);
+    // The response is passed to the function
+    .done(function( json ) {
+       $( "<h1>" ).text( json.title ).appendTo( "body" );
+       $( "<div class=\"content\">").html( json.html ).appendTo( "body" );
+    })
+    // Code to run if the request fails; the raw request and
+    // status codes are passed to the function
+    .fail(function( xhr, status, errorThrown ) {
+      alert( "Sorry, there was a problem!" );
+      console.log( "Error: " + errorThrown );
+      console.log( "Status: " + status );
+      console.dir( xhr );
+    })
+    // Code to run regardless of success or failure;
+    .always(function( xhr, status ) {
+      alert( "The request is complete!" );
+    });
 
-	// Code to run if the request succeeds;
-	// the response is passed to the function
-	success: function( json ) {
-		$( "<h1>" ).text( json.title ).appendTo( "body" );
-		$( "<div class=\"content\">").html( json.html ).appendTo( "body" );
-	},
-
-	// Code to run if the request fails; the raw request and
-	// status codes are passed to the function
-	error: function( xhr, status, errorThrown ) {
-		alert( "Sorry, there was a problem!" );
-		console.log( "Error: " + errorThrown );
-		console.log( "Status: " + status );
-		console.dir( xhr );
-	},
-
-	// Code to run regardless of success or failure
-	complete: function( xhr, status ) {
-		alert( "The request is complete!" );
-	}
-});
 ```
+
 
 **Note:** A note about the `dataType` setting: if the server sends back data that is in a different format than you specify, your code may fail, and the reason will not always be clear, because the HTTP response code will not show an error. When working with Ajax requests, make sure your server is sending back the data type you're asking for, and verify that the `Content-type` header is accurate for the data type. For example, for JSON data, the `Content-type` header should be `application/json`.
 
@@ -68,7 +67,7 @@ Set to `false` if the request should be sent synchronously. Defaults to `true`. 
 
 Whether to use a cached response if available. Defaults to `true` for all `dataType`s except "script" and "jsonp". When set to `false`, the URL will simply have a cachebusting parameter appended to it.
 
-#### complete
+#### always
 
 A callback function to run when the request is complete, regardless of success or failure. The function receives the raw request object and the text status of the request.
 
@@ -84,7 +83,7 @@ The data to be sent to the server. This can either be an object or a query strin
 
 The type of data you expect back from the server. By default, jQuery will look at the MIME type of the response if no `dataType` is specified.
 
-#### error
+#### fail
 
 A callback function to run if the request results in an error. The function receives the raw request object and the text status of the request.
 
@@ -92,7 +91,7 @@ A callback function to run if the request results in an error. The function rece
 
 The callback name to send in a query string when making a JSONP request. Defaults to "callback".
 
-#### success
+#### done
 
 A callback function to run if the request succeeds. The function receives the response data (converted to a JavaScript object if the `dataType` was JSON), as well as the text status of the request and the raw request object.
 

--- a/page/ajax/jquery-ajax-methods.md
+++ b/page/ajax/jquery-ajax-methods.md
@@ -52,7 +52,6 @@ $.ajax({
 
 ```
 
-
 **Note:** A note about the `dataType` setting: if the server sends back data that is in a different format than you specify, your code may fail, and the reason will not always be clear, because the HTTP response code will not show an error. When working with Ajax requests, make sure your server is sending back the data type you're asking for, and verify that the `Content-type` header is accurate for the data type. For example, for JSON data, the `Content-type` header should be `application/json`.
 
 ### `$.ajax()` Options


### PR DESCRIPTION
I'm learning jQ,  so this is by no means going to be  comprehensive but as of the docs:

```
Deprecation Notice: The jqXHR.success(), jqXHR.error(), and jqXHR.complete() callbacks are deprecated as of jQuery 1.8. To prepare your code for their eventual removal, use jqXHR.done(), jqXHR.fail(), and jqXHR.always() instead.
```

I have made changes to reflect these.