### PR TITLE
Pages: Fix typos

### DIFF
--- a/page/code-organization/deferreds/examples.md
+++ b/page/code-organization/deferreds/examples.md
@@ -11,7 +11,7 @@
 
 ## Further Deferreds examples
 
-Deferreds are used behind the hood in Ajax but it doesn't mean they can't also be used elsewhere. This section describes situations where deferreds will help abstract away asynchronous behaviour and decouple our code.
+Deferreds are used behind the hood in Ajax but it doesn't mean they can't also be used elsewhere. This section describes situations where deferreds will help abstract away asynchronous behavior and decouple our code.
 
 ### Caching
 

--- a/page/jquery-ui/widget-factory/extending-widgets.md
+++ b/page/jquery-ui/widget-factory/extending-widgets.md
@@ -23,7 +23,7 @@ Like the previous example, the following also creates a "superDialog" widget in 
 $.widget( "custom.superDialog", $.ui.dialog, {} );
 ```
 
-Here superDialog and dialog are essentially equivalent widgets with different names and namepaces. To make our new widget more interesting we can add methods to its prototype object.
+Here superDialog and dialog are essentially equivalent widgets with different names and namespaces. To make our new widget more interesting we can add methods to its prototype object.
 
 A widget's prototype object is the final argument passed to `$.widget()`. So far, our examples have been using an empty object. Let's add a method to this object:
 

--- a/page/style-guide.md
+++ b/page/style-guide.md
@@ -60,7 +60,7 @@ Content should be educational and accessible to a broad audience of developers. 
 #### Article & Sentence Structure
 
 - Use headings to break up content into easier-to-read sections. Begin headings within an article with `<h2>`.
-- Keep sentences short and to the point. A good rule-of-thumb is to break up any sentence longer than 21 words into two or more seperate thoughts.
+- Keep sentences short and to the point. A good rule-of-thumb is to break up any sentence longer than 21 words into two or more separate thoughts.
 - Lists:
 	- Use bulleted lists when necessary to share a series of five or more points.
 	- Use numbered lists only when providing step-by-step instruction – note that this should be avoided.

--- a/page/using-jquery-core/iterating.md
+++ b/page/using-jquery-core/iterating.md
@@ -115,7 +115,7 @@ $( "li" ).each( function( index, element ){
 
 The question is often raised, "If `this` is the element, why is there a second DOM element argument passed to the callback?"
 
-Whether intentional or inadvert, the execution context may change. When consistently using the keyword `this`, it's easy to end up confusing ourselves or other developers reading the code. Even if the execution context remains the same, it may be more readable to use the second parameter as a named parameter. For example:
+Whether intentional or inadvertent, the execution context may change. When consistently using the keyword `this`, it's easy to end up confusing ourselves or other developers reading the code. Even if the execution context remains the same, it may be more readable to use the second parameter as a named parameter. For example:
 
 ```
 $( "li" ).each( function( index, listItem ) {


### PR DESCRIPTION
behaviour => behavior
inadvert => inadvertent
namepaces => namespaces
seperate => separate
