### PR TITLE
Fix for replace string in example function

### DIFF
--- a/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
+++ b/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
@@ -25,7 +25,7 @@ The following function takes care of escaping these characters and places a "#" 
 ```
 function jq( myid ) {
 
-	return "#" + myid.replace( /(:|\.|\[|\]|,)/g, "\\$1" );
+	return "#" + myid.replace( /(:|\.|\[|\]|,)/g, "\\\\$1" );
 
 }
 ```


### PR DESCRIPTION
I'm on latest Chrome, and the line `return "#" + myid.replace( /(:|\.|\[|\]|,)/g, "\\$1" )` results in only a single backslash being inserted before each match, as opposed to double backslash,

eg `hello:world` > `hello\:world`

Changing to `return "#" + myid.replace( /(:|\.|\[|\]|,)/g, "\\\\$1" )` fixes this.