### PR TITLE
Add = as problematic character and in proposed fix

### DIFF
--- a/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
+++ b/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
@@ -2,7 +2,9 @@
 	"title": "How do I select an element by an ID that has characters used in CSS notation?"
 }</script>
 
-Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation. For example, ID attributes, after an initial letter (a-z or A-Z), may also use periods and colons, in addition to letters, numbers, hyphens, and underscores (see [W3C Basic HTML Data Types](http://www.w3.org/TR/html4/types.html#type-id)). The colon (":") and period (".") are problematic within the context of a jQuery selector because they indicate a pseudo-class and class, respectively.
+Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation. For example, ID attributes, after an initial letter (a-z or A-Z), may also use periods and colons, in addition to letters, numbers, hyphens, and underscores (see [W3C Basic HTML Data Types](http://www.w3.org/TR/html4/types.html#type-id)). The colon (":") and period (".") are problematic within the context of a jQuery selector because they indicate a pseudo-class and class, respectively. 
+
+With HTML5, several more characters are allowed such as equals (=), which is also not supported by jQuery.
 
 In order to tell jQuery to treat these characters literally rather than as CSS notation, they must be "escaped" by placing two backslashes in front of them.
 
@@ -25,7 +27,7 @@ The following function takes care of escaping these characters and places a "#" 
 ```
 function jq( myid ) {
 
-	return "#" + myid.replace( /(:|\.|\[|\]|,)/g, "\\$1" );
+	return "#" + myid.replace( /(:|\.|\[|\]|,|=)/g, "\\$1" );
 
 }
 ```

--- a/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
+++ b/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
@@ -2,11 +2,9 @@
 	"title": "How do I select an element by an ID that has characters used in CSS notation?"
 }</script>
 
-Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation. For example, ID attributes, after an initial letter (a-z or A-Z), may also use periods and colons, in addition to letters, numbers, hyphens, and underscores (see [W3C Basic HTML Data Types](http://www.w3.org/TR/html4/types.html#type-id)). The colon (":") and period (".") are problematic within the context of a jQuery selector because they indicate a pseudo-class and class, respectively. 
+Because jQuery uses CSS syntax for selecting elements, some characters are interpreted as CSS notation. In order to tell jQuery to treat these characters literally rather than as CSS notation, they must be escaped by placing two backslashes in front of them.
 
-With HTML5, several more characters are allowed such as equals (=), which is also not supported by jQuery.
-
-In order to tell jQuery to treat these characters literally rather than as CSS notation, they must be "escaped" by placing two backslashes in front of them.
+See the [Selector documentation](http://api.jquery.com/category/selectors/) for further details.
 
 ```
 // Does not work:


### PR DESCRIPTION
HTML5 allows far more characters for the id attribute than does HTML4. Some of these now-valid characters lead to a syntax error when used with jQuery. The equals sign = is one of these.