### PR TITLE
Will work success on Google Chrome 52.0.2743.116 (64-bit) Mac OS X 10…

### DIFF
--- a/page/using-jquery-core/document-ready.md
+++ b/page/using-jquery-core/document-ready.md
@@ -46,9 +46,9 @@ The example below shows `$( document ).ready()` and `$( window ).load()` in acti
 		console.log( "document loaded" );
 	});
 
-	$( window ).load(function() {
-		console.log( "window loaded" );
-	});
+        $(window).on('load', function () {
+            console.log("window loaded");
+        });
 	</script>
 </head>
 <body>


### PR DESCRIPTION
….11.6

```
$( window ).load(function() {
    console.log( "window loaded" );
});
```
didn't work on Google Chrome 52.0.2743.116 (64-bit) Mac OS X 10.11.6