### PR TITLE
Incorrect explanation. Triggering event isn't an anchor Tag.

### DIFF
--- a/page/events/event-delegation.md
+++ b/page/events/event-delegation.md
@@ -70,7 +70,7 @@ $( "#list" ).on( "click", "a", function( event ) {
 });
 ```
 
-Notice how we have moved the `a` part from the selector to the second parameter position of the `.on()` method. This second, selector parameter tells the handler to listen for the specified event, and when it hears it, check to see if the triggering element for that event matches the second parameter. In this case, the triggering event is our anchor tag, which matches that parameter. Since it matches, our anonymous function will execute. We have now attached a single *click* event listener to our `<ul>` that will listen for clicks on its descendant anchors, instead of attaching an unknown number of directly bound events to the existing anchor tags only.
+Notice how we have moved the `a` part from the selector to the second parameter position of the `.on()` method. This second, selector parameter tells the handler to listen for the specified event, and when it hears it, check to see if the triggering element for that event matches the second parameter. In this case, the triggering element has our anchor tag, which matches that parameter. Since it matches, our anonymous function will execute. We have now attached a single *click* event listener to our `<ul>` that will listen for clicks on its descendant anchors, instead of attaching an unknown number of directly bound events to the existing anchor tags only.
 
 ### Using the Triggering Element
 


### PR DESCRIPTION
The triggering element has a tag which is an anchor tag, in other words, the triggering element's tag is an anchor tag.

Some possible information to add?
The event is Clicking on the element. It's the first element in the bubbling "chain". One could call event.stopPropagation to stop the event from bubbling up the DOM tree.