### PR TITLE
Replace $(window).load with $(window).on("load")

### DIFF
--- a/page/using-jquery-core/document-ready.md
+++ b/page/using-jquery-core/document-ready.md
@@ -3,7 +3,7 @@
 	"level": "beginner"
 }</script>
 
-A page can't be manipulated safely until the document is "ready." jQuery detects this state of readiness for you. Code included inside `$( document ).ready()` will only run once the page Document Object Model (DOM) is ready for JavaScript code to execute. Code included inside `$( window ).load(function() { ... })` will run once the entire page (images or iframes), not just the DOM, is ready.
+A page can't be manipulated safely until the document is "ready." jQuery detects this state of readiness for you. Code included inside `$( document ).ready()` will only run once the page Document Object Model (DOM) is ready for JavaScript code to execute. Code included inside `$( window ).on( "load", function() { ... })` will run once the entire page (images or iframes), not just the DOM, is ready.
 
 ```
 // A $( document ).ready() block.
@@ -32,10 +32,10 @@ function readyFn( jQuery ) {
 
 $( document ).ready( readyFn );
 // or:
-$( window ).load( readyFn );
+$( window ).on( "load", readyFn );
 ```
 
-The example below shows `$( document ).ready()` and `$( window ).load()` in action. The code tries to load a website URL in an `<iframe>` and checks for both events:
+The example below shows `$( document ).ready()` and `$( window ).on( "load" )` in action. The code tries to load a website URL in an `<iframe>` and checks for both events:
 
 ```
 <html>
@@ -46,7 +46,7 @@ The example below shows `$( document ).ready()` and `$( window ).load()` in acti
 		console.log( "document loaded" );
 	});
 
-	$( window ).load(function() {
+	$( window ).on( "load", function() {
 		console.log( "window loaded" );
 	});
 	</script>


### PR DESCRIPTION
According to http://stackoverflow.com/questions/37738732/jquery-3-0-url-indexof-error and https://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/, .load() doesn't exist anymore.