### PR TITLE
Escape @ signs in ID

### DIFF
--- a/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
+++ b/page/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation.md
@@ -25,7 +25,7 @@ The following function takes care of escaping these characters and places a "#" 
 ```
 function jq( myid ) {
 
-	return "#" + myid.replace( /(:|\.|\[|\]|,|=)/g, "\\$1" );
+	return "#" + myid.replace( /(:|\.|\[|\]|,|=|@)/g, "\\$1" );
 
 }
 ```


### PR DESCRIPTION
They lead to Syntax errors otherwise:

```js
$('#canEdit-view23-qwert@fsadfasd\\.yolo');
Error: Syntax error, unrecognized expression: #canEdit-view23-qwert@fsadfasd\.yolo
```