### PR TITLE
fixes typo error

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -19,7 +19,7 @@
 	<div class="row">
 		<aside class="six columns" id="for-users">
 			<h2>Users</h2>
-			<p>There's a lot more to learn about building web sites and applications with jQuery than can fit in API documentation. If you're looking for explanations of the basics, workarounds for common problems, best practices, and how-tos, you're in the right place!</p>
+			<p>There's a lot more to learn about building web sites and applications with jQuery that can fit in API documentation. If you're looking for explanations of the basics, workarounds for common problems, best practices, and how-tos, you're in the right place!</p>
 		</aside>
 
 		<aside class="six columns" id="for-authors">


### PR DESCRIPTION
There was a small typo error in p tag of div id ="for-users" . This branch fixes it.