### PR TITLE
Bug-fix

### DIFF
--- a/page/effects/intro-to-effects.md
+++ b/page/effects/intro-to-effects.md
@@ -92,7 +92,7 @@ A common mistake when implementing jQuery effects is assuming that the execution
 
 ```
 // Fade in all hidden paragraphs; then add a style class to them (not quite right)
-$( "p.hidden" ).fadeIn( 750 ).addClass( "lookAtMe" );
+$( "p:hidden" ).fadeIn( 750 ).addClass( "lookAtMe" );
 ```
 
 It is important to realize that `.fadeIn()` above only *kicks off* the animation. Once started, the animation is implemented by rapidly changing CSS properties in a JavaScript `setInterval()` loop. When you call `.fadeIn()`, it starts the animation loop and then returns the jQuery object, passing it along to `.addClass()` which will then add the `lookAtMe` style class while the animation loop is just getting started.
@@ -101,7 +101,7 @@ To defer an action until after an animation has run to completion, you need to u
 
 ```
 // Fade in all hidden paragraphs; then add a style class to them (correct with animation callback)
-$( "p.hidden" ).fadeIn( 750, function() {
+$( "p:hidden" ).fadeIn( 750, function() {
 	// this = DOM element which has just finished being animated
 	$( this ).addClass( "lookAtMe" );
 });


### PR DESCRIPTION
There is an error in line 104. (And also in line 95, but this is less important.)
The selector $("p.hidden") would find paragraphs that have a class hidden. But this is not the intention. Rather, we want to find classes that are hidden as understood by jQuery. Thus the selector should be:
$("p.hidden")

The difference ist demonstrated by the code below, with two buttons using the different selectors.

<!doctype html>
<html>
	<head>
		<meta charset="utf-8">
		<title>Demo</title>
		<style>
		a.test {
			font-weight: bold;
		}
		.box { border: solid; }
		.lookAtMe { background-color: aqua; }
		
		</style>
		<script src="jquery.js"></script>
	</head>
	<body>
		<p class="box">This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked. This paragraph will fade out when clicked.</p>
	
	
		<button id="TestButtonA">A: Show hidden paragraph and animate it.</button>
		<button id="TestButtonB">B: Show hidden paragraph and animate it.</button>
	<script>
		// Clicking on the paragraph will hide it.
		$( "p" ).on( "click", function() {
			console.log( "click" );
			$(this).hide( 800 );
		});	

		$("#TestButton").on("click", function() {
			// Fade in all hidden paragraphs; then add a style class to them (correct with animation callback)
			$( "p.hidden" ).fadeIn( 750, function() {
				// this = DOM element which has just finished being animated
				$( this ).addClass( "lookAtMe" );
			});
		});

		$("#TestButtonB").on("click", function() {
			// Fade in all hidden paragraphs; then add a style class to them (correct with animation callback)
			$( "p:hidden" ).fadeIn( 750, function() {
				// this = DOM element which has just finished being animated
				$( this ).addClass( "lookAtMe" );
			});
		});
	</script>
	</body>
</html>