### PR TITLE
Contributing: replace @partial with custom @include helper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,26 +4,26 @@ module.exports = function( grunt ) {
 
 grunt.loadNpmTasks( "grunt-jquery-content" );
 
-grunt.initConfig({
+grunt.initConfig( {
 	"build-posts": {
 		page: "page/**"
 	},
 	"build-resources": {
 		all: "resources/**"
 	},
-	wordpress: (function() {
+	wordpress: ( function() {
 		var config = require( "./config" );
 		config.dir = "dist/wordpress";
 		return config;
-	})()
-});
+	} )()
+} );
 
 function getOrderMap() {
 	var map = {},
 		index = 0;
 
 	function walk( items, prefix ) {
-		items.forEach(function( item ) {
+		items.forEach( function( item ) {
 			if ( typeof item === "object" ) {
 				var page = Object.keys( item )[ 0 ];
 				map[ prefix + page ] = ++index;
@@ -31,7 +31,7 @@ function getOrderMap() {
 			} else {
 				map[ prefix + item ] = ++index;
 			}
-		});
+		} );
 	}
 
 	walk( require( "./order" ), "" );
@@ -39,7 +39,7 @@ function getOrderMap() {
 	return map;
 }
 
-jqueryContent.postPreprocessors.page = (function() {
+jqueryContent.postPreprocessors.page = ( function() {
 	var orderMap = getOrderMap();
 
 	return function( post, postPath, callback ) {
@@ -50,9 +50,18 @@ jqueryContent.postPreprocessors.page = (function() {
 			post.menuOrder = menuOrder;
 		}
 
+		// Splice @include(file) directives in here, before grunt-jquery-content
+		// converts the post body. Unlike @partial — which runs after the
+		// Markdown step and HTML-escapes the file for literal/code display —
+		// @include drops the raw source in now so it is converted normally.
+		post.content = post.content.replace( /@include\(\s*(.+?)\s*\)/g,
+			function( _match, input ) {
+				return grunt.file.read( input );
+			} );
+
 		callback( null, post );
 	};
-})();
+} )();
 
 grunt.registerTask( "build", [ "build-posts", "build-resources" ] );
 

--- a/page/contributing.md
+++ b/page/contributing.md
@@ -8,4 +8,4 @@
     ]
 }</script>
 
-@partial(CONTRIBUTING.md)
+@include(CONTRIBUTING.md)


### PR DESCRIPTION
- `@include` inserts the content before grunt processes the markdown, which allows for the markdown to be rendered as HTML on the contributing page
- formatted Gruntfile.js with eslint, which fixed some spacing